### PR TITLE
fix( patch): 修复 path 匹配错误的问题

### DIFF
--- a/patch_flutter/2.2~3.10.patch
+++ b/patch_flutter/2.2~3.10.patch
@@ -1468,7 +1468,7 @@ index 00000000000..971fdf2e598
 +
 +  // 寻找 /flutter/bin/cache
 +  final String normalizedPath = normalize(dartPath);
-+  return Directory(join(normalizedPath.split('/flutter/bin/cache')[0], 'flutter', 'bin', 'cache', pluginAOPRegistry));
++  return Directory(join(normalizedPath.split('/bin/cache')[0], 'bin', 'cache', pluginAOPRegistry));
 +}
 +
 +/// 获取全部AOP工程

--- a/patch_flutter/2.2~3.10.patch
+++ b/patch_flutter/2.2~3.10.patch
@@ -1427,7 +1427,7 @@ new file mode 100644
 index 00000000000..971fdf2e598
 --- /dev/null
 +++ b/packages/flutter_tools/lib/src/aop_tools/interceptor/utils/package_utils.dart
-@@ -0,0 +1,408 @@
+@@ -0,0 +1,401 @@
 +import 'dart:convert';
 +import 'dart:io';
 +import 'dart:math';
@@ -1467,17 +1467,13 @@ index 00000000000..971fdf2e598
 +  }
 +
 +  // 本地引擎调试
-+  if (!dartPath.contains(flutterCacheDirName)) {
++  final String normalizedPath = normalize(dartPath);
++  if (!normalizedPath.contains('/flutter/bin/cache')) {
 +    return Directory(join(normalize(File(dartPath).parent.absolute.path), pluginAOPRegistry));
 +  }
 +
-+  // 寻找最后一个 /flutter/bin/cache 或 \flutter\bin\cache
-+  final int lastCacheIndex = dartPath.lastIndexOf(RegExp(r'[\/\\]flutter[\/\\]bin[\/\\]cache'));
-+  if (lastCacheIndex == -1) {
-+    // 回退方案：使用原有逻辑
-+    return Directory(join(dartPath.split(flutterCacheDirName)[0], flutterCacheDirName, pluginAOPRegistry));
-+  }
-+  return Directory(join(dartPath.substring(0, lastCacheIndex + 1), 'flutter', 'bin', 'cache', pluginAOPRegistry));
++  // 寻找 /flutter/bin/cache
++  return Directory(join(normalizedPath.split('/flutter/bin/cache')[0], 'flutter', 'bin', 'cache', pluginAOPRegistry));
 +}
 +
 +/// 获取全部AOP工程

--- a/patch_flutter/2.2~3.10.patch
+++ b/patch_flutter/2.2~3.10.patch
@@ -10,11 +10,11 @@ Subject: [PATCH] flutterPatch 1.1.3
  .../interceptor/interceptor_manager.dart      |   27 +
  .../interceptor/interface/interceptor.dart    |    5 +
  .../aop_tools/interceptor/utils/constant.dart |  108 ++
- .../interceptor/utils/package_utils.dart      |  400 +++++++
+ .../interceptor/utils/package_utils.dart      |  405 +++++++
  .../lib/src/aop_tools/logger.dart             |   36 +
  .../lib/src/aop_tools/process_decorator.dart  |   65 ++
  .../flutter_tools/lib/src/base/context.dart   |    3 +-
- 10 files changed, 1861 insertions(+), 1 deletion(-)
+ 10 files changed, 1866 insertions(+), 1 deletion(-)
  create mode 100644 packages/flutter_tools/lib/src/aop_tools/interceptor/impl/compile_interceptor.dart
  create mode 100644 packages/flutter_tools/lib/src/aop_tools/interceptor/impl/pub_interceptor.dart
  create mode 100644 packages/flutter_tools/lib/src/aop_tools/interceptor/interceptor_manager.dart
@@ -1427,7 +1427,7 @@ new file mode 100644
 index 00000000000..971fdf2e598
 --- /dev/null
 +++ b/packages/flutter_tools/lib/src/aop_tools/interceptor/utils/package_utils.dart
-@@ -0,0 +1,395 @@
+@@ -0,0 +1,311 @@
 +import 'dart:convert';
 +import 'dart:io';
 +import 'dart:math';
@@ -1466,6 +1466,11 @@ index 00000000000..971fdf2e598
 +    return Directory(join(ProjectConfigExt.flutterRoot!, flutterBinDirName, flutterCacheDirName, pluginAOPRegistry));
 +  }
 +
++  // 本地引擎调试
++  if (!dartPath.contains(flutterCacheDirName)) {
++    return Directory(join(normalize(File(dartPath).parent.absolute.path), pluginAOPRegistry));
++  }
+
 +  // 寻找 /flutter/bin/cache
 +  final String normalizedPath = normalize(dartPath);
 +  return Directory(join(normalizedPath.split('/bin/cache')[0], 'bin', 'cache', pluginAOPRegistry));

--- a/patch_flutter/2.2~3.10.patch
+++ b/patch_flutter/2.2~3.10.patch
@@ -1427,7 +1427,7 @@ new file mode 100644
 index 00000000000..971fdf2e598
 --- /dev/null
 +++ b/packages/flutter_tools/lib/src/aop_tools/interceptor/utils/package_utils.dart
-@@ -0,0 +1,400 @@
+@@ -0,0 +1,408 @@
 +import 'dart:convert';
 +import 'dart:io';
 +import 'dart:math';
@@ -1471,8 +1471,13 @@ index 00000000000..971fdf2e598
 +    return Directory(join(normalize(File(dartPath).parent.absolute.path), pluginAOPRegistry));
 +  }
 +
-+  // 寻找cache目录
-+  return Directory(join(dartPath.split(flutterCacheDirName)[0], flutterCacheDirName, pluginAOPRegistry));
++  // 寻找最后一个 /flutter/bin/cache 或 \flutter\bin\cache
++  final int lastCacheIndex = dartPath.lastIndexOf(RegExp(r'[\/\\]flutter[\/\\]bin[\/\\]cache'));
++  if (lastCacheIndex == -1) {
++    // 回退方案：使用原有逻辑
++    return Directory(join(dartPath.split(flutterCacheDirName)[0], flutterCacheDirName, pluginAOPRegistry));
++  }
++  return Directory(join(dartPath.substring(0, lastCacheIndex + 1), 'flutter', 'bin', 'cache', pluginAOPRegistry));
 +}
 +
 +/// 获取全部AOP工程

--- a/patch_flutter/2.2~3.10.patch
+++ b/patch_flutter/2.2~3.10.patch
@@ -1427,7 +1427,7 @@ new file mode 100644
 index 00000000000..971fdf2e598
 --- /dev/null
 +++ b/packages/flutter_tools/lib/src/aop_tools/interceptor/utils/package_utils.dart
-@@ -0,0 +1,401 @@
+@@ -0,0 +1,395 @@
 +import 'dart:convert';
 +import 'dart:io';
 +import 'dart:math';
@@ -1466,13 +1466,8 @@ index 00000000000..971fdf2e598
 +    return Directory(join(ProjectConfigExt.flutterRoot!, flutterBinDirName, flutterCacheDirName, pluginAOPRegistry));
 +  }
 +
-+  // 本地引擎调试
-+  final String normalizedPath = normalize(dartPath);
-+  if (!normalizedPath.contains('/flutter/bin/cache')) {
-+    return Directory(join(normalize(File(dartPath).parent.absolute.path), pluginAOPRegistry));
-+  }
-+
 +  // 寻找 /flutter/bin/cache
++  final String normalizedPath = normalize(dartPath);
 +  return Directory(join(normalizedPath.split('/flutter/bin/cache')[0], 'flutter', 'bin', 'cache', pluginAOPRegistry));
 +}
 +

--- a/patch_flutter/3.13~3.16.patch
+++ b/patch_flutter/3.13~3.16.patch
@@ -10,11 +10,11 @@ Subject: [PATCH] flutterPatch 1.1.3
  .../interceptor/interceptor_manager.dart      |   27 +
  .../interceptor/interface/interceptor.dart    |    5 +
  .../aop_tools/interceptor/utils/constant.dart |  108 ++
- .../interceptor/utils/package_utils.dart      |  416 +++++++
+ .../interceptor/utils/package_utils.dart      |  421 +++++++
  .../lib/src/aop_tools/logger.dart             |   36 +
  .../lib/src/aop_tools/process_decorator.dart  |   65 ++
  .../flutter_tools/lib/src/base/context.dart   |    3 +-
- 10 files changed, 1877 insertions(+), 1 deletion(-)
+ 10 files changed, 1882 insertions(+), 1 deletion(-)
  create mode 100644 packages/flutter_tools/lib/src/aop_tools/interceptor/impl/compile_interceptor.dart
  create mode 100644 packages/flutter_tools/lib/src/aop_tools/interceptor/impl/pub_interceptor.dart
  create mode 100644 packages/flutter_tools/lib/src/aop_tools/interceptor/interceptor_manager.dart
@@ -1427,7 +1427,7 @@ new file mode 100644
 index 00000000000..5a656d555f9
 --- /dev/null
 +++ b/packages/flutter_tools/lib/src/aop_tools/interceptor/utils/package_utils.dart
-@@ -0,0 +1,411 @@
+@@ -0,0 +1,417 @@
 +import 'dart:convert';
 +import 'dart:io';
 +import 'dart:math';
@@ -1467,6 +1467,11 @@ index 00000000000..5a656d555f9
 +    return Directory(join(ProjectConfigExt.flutterRoot!, flutterBinDirName, flutterCacheDirName, pluginAOPRegistry));
 +  }
 +
++  // 本地引擎调试
++  if (!dartPath.contains(flutterCacheDirName)) {
++    return Directory(join(normalize(File(dartPath).parent.absolute.path), pluginAOPRegistry));
++  }
+
 +  // 寻找 /bin/cache
 +  final String normalizedPath = normalize(dartPath);
 +  return Directory(join(normalizedPath.split('/bin/cache')[0], 'bin', 'cache', pluginAOPRegistry));

--- a/patch_flutter/3.13~3.16.patch
+++ b/patch_flutter/3.13~3.16.patch
@@ -1427,7 +1427,7 @@ new file mode 100644
 index 00000000000..5a656d555f9
 --- /dev/null
 +++ b/packages/flutter_tools/lib/src/aop_tools/interceptor/utils/package_utils.dart
-@@ -0,0 +1,416 @@
+@@ -0,0 +1,424 @@
 +import 'dart:convert';
 +import 'dart:io';
 +import 'dart:math';
@@ -1472,8 +1472,13 @@ index 00000000000..5a656d555f9
 +    return Directory(join(normalize(File(dartPath).parent.absolute.path), pluginAOPRegistry));
 +  }
 +
-+  // 寻找cache目录
-+  return Directory(join(dartPath.split(flutterCacheDirName)[0], flutterCacheDirName, pluginAOPRegistry));
++  // 寻找最后一个 /flutter/bin/cache 或 \flutter\bin\cache
++  final int lastCacheIndex = dartPath.lastIndexOf(RegExp(r'[\/\\]flutter[\/\\]bin[\/\\]cache'));
++  if (lastCacheIndex == -1) {
++    // 回退方案：使用原有逻辑
++    return Directory(join(dartPath.split(flutterCacheDirName)[0], flutterCacheDirName, pluginAOPRegistry));
++  }
++  return Directory(join(dartPath.substring(0, lastCacheIndex + 1), 'flutter', 'bin', 'cache', pluginAOPRegistry));
 +}
 +
 +/// 获取全部AOP工程

--- a/patch_flutter/3.13~3.16.patch
+++ b/patch_flutter/3.13~3.16.patch
@@ -1427,7 +1427,7 @@ new file mode 100644
 index 00000000000..5a656d555f9
 --- /dev/null
 +++ b/packages/flutter_tools/lib/src/aop_tools/interceptor/utils/package_utils.dart
-@@ -0,0 +1,424 @@
+@@ -0,0 +1,417 @@
 +import 'dart:convert';
 +import 'dart:io';
 +import 'dart:math';
@@ -1468,17 +1468,13 @@ index 00000000000..5a656d555f9
 +  }
 +
 +  // 本地引擎调试
-+  if (!dartPath.contains(flutterCacheDirName)) {
++  final String normalizedPath = normalize(dartPath);
++  if (!normalizedPath.contains('/flutter/bin/cache')) {
 +    return Directory(join(normalize(File(dartPath).parent.absolute.path), pluginAOPRegistry));
 +  }
 +
-+  // 寻找最后一个 /flutter/bin/cache 或 \flutter\bin\cache
-+  final int lastCacheIndex = dartPath.lastIndexOf(RegExp(r'[\/\\]flutter[\/\\]bin[\/\\]cache'));
-+  if (lastCacheIndex == -1) {
-+    // 回退方案：使用原有逻辑
-+    return Directory(join(dartPath.split(flutterCacheDirName)[0], flutterCacheDirName, pluginAOPRegistry));
-+  }
-+  return Directory(join(dartPath.substring(0, lastCacheIndex + 1), 'flutter', 'bin', 'cache', pluginAOPRegistry));
++  // 寻找 /flutter/bin/cache
++  return Directory(join(normalizedPath.split('/flutter/bin/cache')[0], 'flutter', 'bin', 'cache', pluginAOPRegistry));
 +}
 +
 +/// 获取全部AOP工程

--- a/patch_flutter/3.13~3.16.patch
+++ b/patch_flutter/3.13~3.16.patch
@@ -1427,7 +1427,7 @@ new file mode 100644
 index 00000000000..5a656d555f9
 --- /dev/null
 +++ b/packages/flutter_tools/lib/src/aop_tools/interceptor/utils/package_utils.dart
-@@ -0,0 +1,417 @@
+@@ -0,0 +1,411 @@
 +import 'dart:convert';
 +import 'dart:io';
 +import 'dart:math';
@@ -1467,13 +1467,8 @@ index 00000000000..5a656d555f9
 +    return Directory(join(ProjectConfigExt.flutterRoot!, flutterBinDirName, flutterCacheDirName, pluginAOPRegistry));
 +  }
 +
-+  // 本地引擎调试
-+  final String normalizedPath = normalize(dartPath);
-+  if (!normalizedPath.contains('/flutter/bin/cache')) {
-+    return Directory(join(normalize(File(dartPath).parent.absolute.path), pluginAOPRegistry));
-+  }
-+
 +  // 寻找 /flutter/bin/cache
++  final String normalizedPath = normalize(dartPath);
 +  return Directory(join(normalizedPath.split('/flutter/bin/cache')[0], 'flutter', 'bin', 'cache', pluginAOPRegistry));
 +}
 +

--- a/patch_flutter/3.13~3.16.patch
+++ b/patch_flutter/3.13~3.16.patch
@@ -1467,9 +1467,9 @@ index 00000000000..5a656d555f9
 +    return Directory(join(ProjectConfigExt.flutterRoot!, flutterBinDirName, flutterCacheDirName, pluginAOPRegistry));
 +  }
 +
-+  // 寻找 /flutter/bin/cache
++  // 寻找 /bin/cache
 +  final String normalizedPath = normalize(dartPath);
-+  return Directory(join(normalizedPath.split('/flutter/bin/cache')[0], 'flutter', 'bin', 'cache', pluginAOPRegistry));
++  return Directory(join(normalizedPath.split('/bin/cache')[0], 'bin', 'cache', pluginAOPRegistry));
 +}
 +
 +/// 获取全部AOP工程

--- a/patch_flutter/3.19~3.22.patch
+++ b/patch_flutter/3.19~3.22.patch
@@ -1467,7 +1467,7 @@ new file mode 100644
 index 00000000000..5a656d555f9
 --- /dev/null
 +++ b/packages/flutter_tools/lib/src/aop_tools/interceptor/utils/package_utils.dart
-@@ -0,0 +1,416 @@
+@@ -0,0 +1,424 @@
 +import 'dart:convert';
 +import 'dart:io';
 +import 'dart:math';
@@ -1512,8 +1512,13 @@ index 00000000000..5a656d555f9
 +    return Directory(join(normalize(File(dartPath).parent.absolute.path), pluginAOPRegistry));
 +  }
 +
-+  // 寻找cache目录
-+  return Directory(join(dartPath.split(flutterCacheDirName)[0], flutterCacheDirName, pluginAOPRegistry));
++  // 寻找最后一个 /flutter/bin/cache 或 \flutter\bin\cache
++  final int lastCacheIndex = dartPath.lastIndexOf(RegExp(r'[\/\\]flutter[\/\\]bin[\/\\]cache'));
++  if (lastCacheIndex == -1) {
++    // 回退方案：使用原有逻辑
++    return Directory(join(dartPath.split(flutterCacheDirName)[0], flutterCacheDirName, pluginAOPRegistry));
++  }
++  return Directory(join(dartPath.substring(0, lastCacheIndex + 1), 'flutter', 'bin', 'cache', pluginAOPRegistry));
 +}
 +
 +/// 获取全部AOP工程

--- a/patch_flutter/3.19~3.22.patch
+++ b/patch_flutter/3.19~3.22.patch
@@ -1507,9 +1507,9 @@ index 00000000000..5a656d555f9
 +    return Directory(join(ProjectConfigExt.flutterRoot!, flutterBinDirName, flutterCacheDirName, pluginAOPRegistry));
 +  }
 +
-+  // 寻找 /flutter/bin/cache
++  // 寻找 /bin/cache
 +  final String normalizedPath = normalize(dartPath);
-+  return Directory(join(normalizedPath.split('/flutter/bin/cache')[0], 'flutter', 'bin', 'cache', pluginAOPRegistry));
++  return Directory(join(normalizedPath.split('/bin/cache')[0], 'bin', 'cache', pluginAOPRegistry));
 +}
 +
 +/// 获取全部AOP工程

--- a/patch_flutter/3.19~3.22.patch
+++ b/patch_flutter/3.19~3.22.patch
@@ -1467,7 +1467,7 @@ new file mode 100644
 index 00000000000..5a656d555f9
 --- /dev/null
 +++ b/packages/flutter_tools/lib/src/aop_tools/interceptor/utils/package_utils.dart
-@@ -0,0 +1,424 @@
+@@ -0,0 +1,417 @@
 +import 'dart:convert';
 +import 'dart:io';
 +import 'dart:math';
@@ -1508,17 +1508,13 @@ index 00000000000..5a656d555f9
 +  }
 +
 +  // 本地引擎调试
-+  if (!dartPath.contains(flutterCacheDirName)) {
++  final String normalizedPath = normalize(dartPath);
++  if (!normalizedPath.contains('/flutter/bin/cache')) {
 +    return Directory(join(normalize(File(dartPath).parent.absolute.path), pluginAOPRegistry));
 +  }
 +
-+  // 寻找最后一个 /flutter/bin/cache 或 \flutter\bin\cache
-+  final int lastCacheIndex = dartPath.lastIndexOf(RegExp(r'[\/\\]flutter[\/\\]bin[\/\\]cache'));
-+  if (lastCacheIndex == -1) {
-+    // 回退方案：使用原有逻辑
-+    return Directory(join(dartPath.split(flutterCacheDirName)[0], flutterCacheDirName, pluginAOPRegistry));
-+  }
-+  return Directory(join(dartPath.substring(0, lastCacheIndex + 1), 'flutter', 'bin', 'cache', pluginAOPRegistry));
++  // 寻找 /flutter/bin/cache
++  return Directory(join(normalizedPath.split('/flutter/bin/cache')[0], 'flutter', 'bin', 'cache', pluginAOPRegistry));
 +}
 +
 +/// 获取全部AOP工程

--- a/patch_flutter/3.19~3.22.patch
+++ b/patch_flutter/3.19~3.22.patch
@@ -10,11 +10,11 @@ Subject: [PATCH] flutterPatch 1.1.3
  .../interceptor/interceptor_manager.dart      |   28 +
  .../interceptor/interface/interceptor.dart    |    5 +
  .../aop_tools/interceptor/utils/constant.dart |  110 ++
- .../interceptor/utils/package_utils.dart      |  416 +++++++
+ .../interceptor/utils/package_utils.dart      |  421 +++++++
  .../lib/src/aop_tools/logger.dart             |   36 +
  .../lib/src/aop_tools/process_decorator.dart  |   65 +
  .../flutter_tools/lib/src/base/context.dart   |    3 +-
- 10 files changed, 1917 insertions(+), 1 deletion(-)
+ 10 files changed, 1922 insertions(+), 1 deletion(-)
  create mode 100644 packages/flutter_tools/lib/src/aop_tools/interceptor/impl/compile_interceptor.dart
  create mode 100644 packages/flutter_tools/lib/src/aop_tools/interceptor/impl/pub_interceptor.dart
  create mode 100644 packages/flutter_tools/lib/src/aop_tools/interceptor/interceptor_manager.dart
@@ -1467,7 +1467,7 @@ new file mode 100644
 index 00000000000..5a656d555f9
 --- /dev/null
 +++ b/packages/flutter_tools/lib/src/aop_tools/interceptor/utils/package_utils.dart
-@@ -0,0 +1,411 @@
+@@ -0,0 +1,417 @@
 +import 'dart:convert';
 +import 'dart:io';
 +import 'dart:math';
@@ -1507,6 +1507,11 @@ index 00000000000..5a656d555f9
 +    return Directory(join(ProjectConfigExt.flutterRoot!, flutterBinDirName, flutterCacheDirName, pluginAOPRegistry));
 +  }
 +
++  // 本地引擎调试
++  if (!dartPath.contains(flutterCacheDirName)) {
++    return Directory(join(normalize(File(dartPath).parent.absolute.path), pluginAOPRegistry));
++  }
+
 +  // 寻找 /bin/cache
 +  final String normalizedPath = normalize(dartPath);
 +  return Directory(join(normalizedPath.split('/bin/cache')[0], 'bin', 'cache', pluginAOPRegistry));

--- a/patch_flutter/3.19~3.22.patch
+++ b/patch_flutter/3.19~3.22.patch
@@ -1467,7 +1467,7 @@ new file mode 100644
 index 00000000000..5a656d555f9
 --- /dev/null
 +++ b/packages/flutter_tools/lib/src/aop_tools/interceptor/utils/package_utils.dart
-@@ -0,0 +1,417 @@
+@@ -0,0 +1,411 @@
 +import 'dart:convert';
 +import 'dart:io';
 +import 'dart:math';
@@ -1507,13 +1507,8 @@ index 00000000000..5a656d555f9
 +    return Directory(join(ProjectConfigExt.flutterRoot!, flutterBinDirName, flutterCacheDirName, pluginAOPRegistry));
 +  }
 +
-+  // 本地引擎调试
-+  final String normalizedPath = normalize(dartPath);
-+  if (!normalizedPath.contains('/flutter/bin/cache')) {
-+    return Directory(join(normalize(File(dartPath).parent.absolute.path), pluginAOPRegistry));
-+  }
-+
 +  // 寻找 /flutter/bin/cache
++  final String normalizedPath = normalize(dartPath);
 +  return Directory(join(normalizedPath.split('/flutter/bin/cache')[0], 'flutter', 'bin', 'cache', pluginAOPRegistry));
 +}
 +

--- a/patch_flutter/3.24~3.32.patch
+++ b/patch_flutter/3.24~3.32.patch
@@ -1467,7 +1467,7 @@ new file mode 100644
 index 00000000000..14ee069b7b5
 --- /dev/null
 +++ b/packages/flutter_tools/lib/src/aop_tools/interceptor/utils/package_utils.dart
-@@ -0,0 +1,415 @@
+@@ -0,0 +1,423 @@
 +import 'dart:convert';
 +import 'dart:io';
 +import 'dart:math';
@@ -1512,8 +1512,13 @@ index 00000000000..14ee069b7b5
 +    return Directory(join(normalize(File(dartPath).parent.absolute.path), pluginAOPRegistry));
 +  }
 +
-+  // 寻找cache目录
-+  return Directory(join(dartPath.split(flutterCacheDirName)[0], flutterCacheDirName, pluginAOPRegistry));
++  // 寻找最后一个 /flutter/bin/cache 或 \flutter\bin\cache
++  final int lastCacheIndex = dartPath.lastIndexOf(RegExp(r'[\/\\]flutter[\/\\]bin[\/\\]cache'));
++  if (lastCacheIndex == -1) {
++    // 回退方案：使用原有逻辑
++    return Directory(join(dartPath.split(flutterCacheDirName)[0], flutterCacheDirName, pluginAOPRegistry));
++  }
++  return Directory(join(dartPath.substring(0, lastCacheIndex + 1), 'flutter', 'bin', 'cache', pluginAOPRegistry));
 +}
 +
 +/// 获取全部AOP工程

--- a/patch_flutter/3.24~3.32.patch
+++ b/patch_flutter/3.24~3.32.patch
@@ -10,11 +10,11 @@ Subject: [PATCH] flutterPatch 1.1.3
  .../interceptor/interceptor_manager.dart      |   28 +
  .../interceptor/interface/interceptor.dart    |    5 +
  .../aop_tools/interceptor/utils/constant.dart |  110 ++
- .../interceptor/utils/package_utils.dart      |  415 +++++++
+ .../interceptor/utils/package_utils.dart      |  420 +++++++
  .../lib/src/aop_tools/logger.dart             |   36 +
  .../lib/src/aop_tools/process_decorator.dart  |   65 +
  .../flutter_tools/lib/src/base/context.dart   |    3 +-
- 10 files changed, 1916 insertions(+), 1 deletion(-)
+ 10 files changed, 1921 insertions(+), 1 deletion(-)
  create mode 100644 packages/flutter_tools/lib/src/aop_tools/interceptor/impl/compile_interceptor.dart
  create mode 100644 packages/flutter_tools/lib/src/aop_tools/interceptor/impl/pub_interceptor.dart
  create mode 100644 packages/flutter_tools/lib/src/aop_tools/interceptor/interceptor_manager.dart
@@ -1467,7 +1467,7 @@ new file mode 100644
 index 00000000000..14ee069b7b5
 --- /dev/null
 +++ b/packages/flutter_tools/lib/src/aop_tools/interceptor/utils/package_utils.dart
-@@ -0,0 +1,410 @@
+@@ -0,0 +1,416 @@
 +import 'dart:convert';
 +import 'dart:io';
 +import 'dart:math';
@@ -1505,6 +1505,11 @@ index 00000000000..14ee069b7b5
 +Directory fetchAOPRegistry(String dartPath) {
 +  if (ProjectConfigExt.flutterRoot != null) {
 +    return Directory(join(ProjectConfigExt.flutterRoot!, flutterBinDirName, flutterCacheDirName, pluginAOPRegistry));
++  }
++
++  // 本地引擎调试
++  if (!dartPath.contains(flutterCacheDirName)) {
++    return Directory(join(normalize(File(dartPath).parent.absolute.path), pluginAOPRegistry));
 +  }
 +
 +  // 寻找 /bin/cache

--- a/patch_flutter/3.24~3.32.patch
+++ b/patch_flutter/3.24~3.32.patch
@@ -1467,7 +1467,7 @@ new file mode 100644
 index 00000000000..14ee069b7b5
 --- /dev/null
 +++ b/packages/flutter_tools/lib/src/aop_tools/interceptor/utils/package_utils.dart
-@@ -0,0 +1,416 @@
+@@ -0,0 +1,410 @@
 +import 'dart:convert';
 +import 'dart:io';
 +import 'dart:math';
@@ -1507,13 +1507,8 @@ index 00000000000..14ee069b7b5
 +    return Directory(join(ProjectConfigExt.flutterRoot!, flutterBinDirName, flutterCacheDirName, pluginAOPRegistry));
 +  }
 +
-+  // 本地引擎调试
-+  final String normalizedPath = normalize(dartPath);
-+  if (!normalizedPath.contains('/flutter/bin/cache')) {
-+    return Directory(join(normalize(File(dartPath).parent.absolute.path), pluginAOPRegistry));
-+  }
-+
 +  // 寻找 /flutter/bin/cache
++  final String normalizedPath = normalize(dartPath);
 +  return Directory(join(normalizedPath.split('/flutter/bin/cache')[0], 'flutter', 'bin', 'cache', pluginAOPRegistry));
 +}
 +

--- a/patch_flutter/3.24~3.32.patch
+++ b/patch_flutter/3.24~3.32.patch
@@ -1507,9 +1507,9 @@ index 00000000000..14ee069b7b5
 +    return Directory(join(ProjectConfigExt.flutterRoot!, flutterBinDirName, flutterCacheDirName, pluginAOPRegistry));
 +  }
 +
-+  // 寻找 /flutter/bin/cache
++  // 寻找 /bin/cache
 +  final String normalizedPath = normalize(dartPath);
-+  return Directory(join(normalizedPath.split('/flutter/bin/cache')[0], 'flutter', 'bin', 'cache', pluginAOPRegistry));
++  return Directory(join(normalizedPath.split('/bin/cache')[0], 'bin', 'cache', pluginAOPRegistry));
 +}
 +
 +/// 获取全部AOP工程

--- a/patch_flutter/3.24~3.32.patch
+++ b/patch_flutter/3.24~3.32.patch
@@ -1467,7 +1467,7 @@ new file mode 100644
 index 00000000000..14ee069b7b5
 --- /dev/null
 +++ b/packages/flutter_tools/lib/src/aop_tools/interceptor/utils/package_utils.dart
-@@ -0,0 +1,423 @@
+@@ -0,0 +1,416 @@
 +import 'dart:convert';
 +import 'dart:io';
 +import 'dart:math';
@@ -1508,17 +1508,13 @@ index 00000000000..14ee069b7b5
 +  }
 +
 +  // 本地引擎调试
-+  if (!dartPath.contains(flutterCacheDirName)) {
++  final String normalizedPath = normalize(dartPath);
++  if (!normalizedPath.contains('/flutter/bin/cache')) {
 +    return Directory(join(normalize(File(dartPath).parent.absolute.path), pluginAOPRegistry));
 +  }
 +
-+  // 寻找最后一个 /flutter/bin/cache 或 \flutter\bin\cache
-+  final int lastCacheIndex = dartPath.lastIndexOf(RegExp(r'[\/\\]flutter[\/\\]bin[\/\\]cache'));
-+  if (lastCacheIndex == -1) {
-+    // 回退方案：使用原有逻辑
-+    return Directory(join(dartPath.split(flutterCacheDirName)[0], flutterCacheDirName, pluginAOPRegistry));
-+  }
-+  return Directory(join(dartPath.substring(0, lastCacheIndex + 1), 'flutter', 'bin', 'cache', pluginAOPRegistry));
++  // 寻找 /flutter/bin/cache
++  return Directory(join(normalizedPath.split('/flutter/bin/cache')[0], 'flutter', 'bin', 'cache', pluginAOPRegistry));
 +}
 +
 +/// 获取全部AOP工程

--- a/patch_flutter/3.35~infinity.patch
+++ b/patch_flutter/3.35~infinity.patch
@@ -10,11 +10,11 @@ Subject: [PATCH] flutterPatch 1.1.3
  .../interceptor/interceptor_manager.dart      |   28 +
  .../interceptor/interface/interceptor.dart    |    5 +
  .../aop_tools/interceptor/utils/constant.dart |  110 ++
- .../interceptor/utils/package_utils.dart      |  415 +++++++
+ .../interceptor/utils/package_utils.dart      |  420 +++++++
  .../lib/src/aop_tools/logger.dart             |   36 +
  .../lib/src/aop_tools/process_decorator.dart  |   65 +
  .../flutter_tools/lib/src/base/context.dart   |    3 +-
- 10 files changed, 1916 insertions(+), 1 deletion(-)
+ 10 files changed, 1921 insertions(+), 1 deletion(-)
  create mode 100644 packages/flutter_tools/lib/src/aop_tools/interceptor/impl/compile_interceptor.dart
  create mode 100644 packages/flutter_tools/lib/src/aop_tools/interceptor/impl/pub_interceptor.dart
  create mode 100644 packages/flutter_tools/lib/src/aop_tools/interceptor/interceptor_manager.dart
@@ -1467,7 +1467,7 @@ new file mode 100644
 index 00000000000..14ee069b7b5
 --- /dev/null
 +++ b/packages/flutter_tools/lib/src/aop_tools/interceptor/utils/package_utils.dart
-@@ -0,0 +1,410 @@
+@@ -0,0 +1,416 @@
 +import 'dart:convert';
 +import 'dart:io';
 +import 'dart:math';
@@ -1505,6 +1505,11 @@ index 00000000000..14ee069b7b5
 +Directory fetchAOPRegistry(String dartPath) {
 +  if (ProjectConfigExt.flutterRoot != null) {
 +    return Directory(join(ProjectConfigExt.flutterRoot!, flutterBinDirName, flutterCacheDirName, pluginAOPRegistry));
++  }
++
++  // 本地引擎调试
++  if (!dartPath.contains(flutterCacheDirName)) {
++    return Directory(join(normalize(File(dartPath).parent.absolute.path), pluginAOPRegistry));
 +  }
 +
 +  // 寻找 /bin/cache

--- a/patch_flutter/3.35~infinity.patch
+++ b/patch_flutter/3.35~infinity.patch
@@ -1467,7 +1467,7 @@ new file mode 100644
 index 00000000000..14ee069b7b5
 --- /dev/null
 +++ b/packages/flutter_tools/lib/src/aop_tools/interceptor/utils/package_utils.dart
-@@ -0,0 +1,416 @@
+@@ -0,0 +1,410 @@
 +import 'dart:convert';
 +import 'dart:io';
 +import 'dart:math';
@@ -1507,13 +1507,8 @@ index 00000000000..14ee069b7b5
 +    return Directory(join(ProjectConfigExt.flutterRoot!, flutterBinDirName, flutterCacheDirName, pluginAOPRegistry));
 +  }
 +
-+  // 本地引擎调试
-+  final String normalizedPath = normalize(dartPath);
-+  if (!normalizedPath.contains('/flutter/bin/cache')) {
-+    return Directory(join(normalize(File(dartPath).parent.absolute.path), pluginAOPRegistry));
-+  }
-+
 +  // 寻找 /flutter/bin/cache
++  final String normalizedPath = normalize(dartPath);
 +  return Directory(join(normalizedPath.split('/flutter/bin/cache')[0], 'flutter', 'bin', 'cache', pluginAOPRegistry));
 +}
 +

--- a/patch_flutter/3.35~infinity.patch
+++ b/patch_flutter/3.35~infinity.patch
@@ -1507,9 +1507,9 @@ index 00000000000..14ee069b7b5
 +    return Directory(join(ProjectConfigExt.flutterRoot!, flutterBinDirName, flutterCacheDirName, pluginAOPRegistry));
 +  }
 +
-+  // 寻找 /flutter/bin/cache
++  // 寻找 /bin/cache
 +  final String normalizedPath = normalize(dartPath);
-+  return Directory(join(normalizedPath.split('/flutter/bin/cache')[0], 'flutter', 'bin', 'cache', pluginAOPRegistry));
++  return Directory(join(normalizedPath.split('/bin/cache')[0], 'bin', 'cache', pluginAOPRegistry));
 +}
 +
 +/// 获取全部AOP工程

--- a/patch_flutter/3.35~infinity.patch
+++ b/patch_flutter/3.35~infinity.patch
@@ -1467,7 +1467,7 @@ new file mode 100644
 index 00000000000..14ee069b7b5
 --- /dev/null
 +++ b/packages/flutter_tools/lib/src/aop_tools/interceptor/utils/package_utils.dart
-@@ -0,0 +1,420 @@
+@@ -0,0 +1,416 @@
 +import 'dart:convert';
 +import 'dart:io';
 +import 'dart:math';
@@ -1508,17 +1508,13 @@ index 00000000000..14ee069b7b5
 +  }
 +
 +  // 本地引擎调试
-+  if (!dartPath.contains(flutterCacheDirName)) {
++  final String normalizedPath = normalize(dartPath);
++  if (!normalizedPath.contains('/flutter/bin/cache')) {
 +    return Directory(join(normalize(File(dartPath).parent.absolute.path), pluginAOPRegistry));
 +  }
 +
-+  // 寻找最后一个 /flutter/bin/cache 或 \flutter\bin\cache
-+  final int lastCacheIndex = dartPath.lastIndexOf(RegExp(r'[\/\\]flutter[\/\\]bin[\/\\]cache'));
-+  if (lastCacheIndex == -1) {
-+    // 回退方案：使用原有逻辑
-+    return Directory(join(dartPath.split(flutterCacheDirName)[0], flutterCacheDirName, pluginAOPRegistry));
-+  }
-+  return Directory(join(dartPath.substring(0, lastCacheIndex + 1), 'flutter', 'bin', 'cache', pluginAOPRegistry));
++  // 寻找 /flutter/bin/cache
++  return Directory(join(normalizedPath.split('/flutter/bin/cache')[0], 'flutter', 'bin', 'cache', pluginAOPRegistry));
 +}
 +
 +/// 获取全部AOP工程

--- a/patch_flutter/3.35~infinity.patch
+++ b/patch_flutter/3.35~infinity.patch
@@ -1467,7 +1467,7 @@ new file mode 100644
 index 00000000000..14ee069b7b5
 --- /dev/null
 +++ b/packages/flutter_tools/lib/src/aop_tools/interceptor/utils/package_utils.dart
-@@ -0,0 +1,415 @@
+@@ -0,0 +1,420 @@
 +import 'dart:convert';
 +import 'dart:io';
 +import 'dart:math';
@@ -1512,8 +1512,13 @@ index 00000000000..14ee069b7b5
 +    return Directory(join(normalize(File(dartPath).parent.absolute.path), pluginAOPRegistry));
 +  }
 +
-+  // 寻找cache目录
-+  return Directory(join(dartPath.split(flutterCacheDirName)[0], flutterCacheDirName, pluginAOPRegistry));
++  // 寻找最后一个 /flutter/bin/cache 或 \flutter\bin\cache
++  final int lastCacheIndex = dartPath.lastIndexOf(RegExp(r'[\/\\]flutter[\/\\]bin[\/\\]cache'));
++  if (lastCacheIndex == -1) {
++    // 回退方案：使用原有逻辑
++    return Directory(join(dartPath.split(flutterCacheDirName)[0], flutterCacheDirName, pluginAOPRegistry));
++  }
++  return Directory(join(dartPath.substring(0, lastCacheIndex + 1), 'flutter', 'bin', 'cache', pluginAOPRegistry));
 +}
 +
 +/// 获取全部AOP工程


### PR DESCRIPTION
之前的匹配:`cachetest/flutter/bin/cache`  会获取新的路径为 `cache/` 而不是全路径。
现在匹配 `/bin/cache` 然后拼接 `pluginAOPRegistry`